### PR TITLE
Null error for table name generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2019-05-14
+
+## Bugfix
+- `SoftReferenceInstanceNameTableColumnGenerator` renders null references correctly instead of throwing an error
+
 ## [0.5.0] - 2019-02-23
 
 ## Added

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ subprojects {
     apply plugin: 'com.jfrog.bintray'
 
     bintray {
-        user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('UPLOAD_REPOSITORY_USERNAME')
-        key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('UPLOAD_REPOSITORY_PASSWORD')
+        user = System.getenv('BINTRAY_USERNAME')
+        key = System.getenv('BINTRAY_PASSWORD')
 
         configurations = ['archives']
 

--- a/modules/web/src/de/diedavids/cuba/entitysoftreference/web/SoftReferenceInstanceNameTableColumnGenerator.java
+++ b/modules/web/src/de/diedavids/cuba/entitysoftreference/web/SoftReferenceInstanceNameTableColumnGenerator.java
@@ -64,7 +64,13 @@ public class SoftReferenceInstanceNameTableColumnGenerator implements Table.Colu
     }
 
     private LinkButton softReferenceLinkButton(Entity entitySoftReference) {
+
+        if (entitySoftReference == null) {
+            return null;
+        }
+
         LinkButton linkButton = uiComponents.create(LinkButton.class);
+
         linkButton.setCaption(metadataTools.getInstanceName(entitySoftReference));
 
         linkButton.addClickListener(clickEvent -> {


### PR DESCRIPTION
Fixes the problem, that in case the entity reference is null, an error is thrown. Instead now nothing is rendered.